### PR TITLE
Add Smithery to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Kagi MCP server
 
+[![smithery badge](https://smithery.ai/badge/kagimcp)](https://smithery.ai/protocol/kagimcp)
+
 ## Setup Intructions
 Install uv first.
 
@@ -11,6 +13,14 @@ curl -LsSf https://astral.sh/uv/install.sh | sh
 Windows:
 ```
 powershell -ExecutionPolicy ByPass -c "irm https://astral.sh/uv/install.ps1 | iex"
+```
+
+### Installing via Smithery
+
+To install Kagi MCP for Claude Desktop automatically via [Smithery](https://smithery.ai/protocol/kagimcp):
+
+```bash
+npx -y @smithery/cli install kagimcp --client claude
 ```
 
 ### Setup with Claude Desktop


### PR DESCRIPTION
This PR makes two changes to the README.

1. Adds installation instructions to automatically install Kagi for Claude Desktop using Smithery CLI. This makes it easier for users to install the MCP.
2. Adds a badge to show the number of installations from Smithery: https://smithery.ai/protocol/kagimcp

Let me know if any tweaks have to be made!