### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 [![smithery badge](https://smithery.ai/badge/kagimcp)](https://smithery.ai/server/kagimcp)
 
+<a href="https://glama.ai/mcp/servers/xabrrs4bka">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/xabrrs4bka/badge" alt="Kagi Server MCP server" />
+</a>
+
 ## Setup Intructions
 > Before anything, ensure you have access to the search API. It is currently in closed beta and available upon request. Please reach out to support@kagi.com for an invite.
 


### PR DESCRIPTION
This PR adds a badge for the [Kagi MCP Server](https://glama.ai/mcp/servers/xabrrs4bka) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/xabrrs4bka">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/xabrrs4bka/badge" alt="Kagi Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.