### PR TITLE
Add kagi_fastgpt tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,14 @@
   <img width="380" height="200" src="https://glama.ai/mcp/servers/xabrrs4bka/badge" alt="Kagi Server MCP server" />
 </a>
 
+## Tools
+
+- `kagi_search_fetch` — Kagi Search API (closed beta, email support@kagi.com for access).
+- `kagi_summarizer` — Kagi Universal Summarizer; summarizes any URL (text, video, audio).
+- `kagi_fastgpt` — Kagi FastGPT; returns a concise, cited answer to a natural-language question using live web search.
+
+`kagi_summarizer` and `kagi_fastgpt` work with any standard Kagi API key. `kagi_search_fetch` additionally requires Search API beta access.
+
 ## Setup Intructions
 > Before anything, unless you are just using non-search tools, ensure you have access to the search API. It is currently in closed beta and available upon request. Please reach out to support@kagi.com for an invite.
 

--- a/src/kagimcp/server.py
+++ b/src/kagimcp/server.py
@@ -132,6 +132,70 @@ def kagi_summarizer(
     return summary
 
 
+@mcp.tool()
+def kagi_fastgpt(
+    query: str = Field(
+        description="A natural-language question or prompt. FastGPT returns a concise answer grounded in live web search with inline citations."
+    ),
+    cache: bool = Field(
+        default=True,
+        description="Whether to allow Kagi to serve a cached answer. Set to False to force a fresh search.",
+    ),
+) -> str:
+    """Answer a question using Kagi FastGPT. FastGPT combines live web search with an LLM to produce a short, cited answer. Use for factual questions where a direct synthesized answer with sources is more useful than a raw list of search results. Output includes the answer followed by numbered references."""
+    if not query:
+        raise ValueError("FastGPT called with no query.")
+
+    # NOTE: kagiapi 0.2.1 serializes `cache` as a JSON string instead of a
+    # bool, which the FastGPT endpoint rejects. Call the endpoint directly
+    # via the client's authenticated session to sidestep the bug.
+    payload: dict = {"query": query, "cache": bool(cache)}
+    try:
+        http_response = kagi_client.session.post(
+            kagi_client.BASE_URL + "/fastgpt",
+            json=payload,
+            timeout=30,
+        )
+        http_response.raise_for_status()
+        response = http_response.json()
+    except Exception as e:
+        raise ValueError(f"Error calling Kagi FastGPT API: {e}")
+
+    if error := response.get("error"):
+        raise ValueError(error)
+
+    return format_fastgpt_response(response["data"])
+
+
+def format_fastgpt_response(data: dict) -> str:
+    """Format a FastGPT data block as answer text followed by numbered references."""
+    output = data.get("output", "").strip()
+    references = data.get("references") or []
+
+    if not references:
+        return output
+
+    ref_template = textwrap.dedent(
+        """
+        [{n}] {title}
+        {url}
+        {snippet}
+    """
+    ).strip()
+
+    formatted_refs = "\n\n".join(
+        ref_template.format(
+            n=i,
+            title=ref.get("title", "Not Available"),
+            url=ref.get("url", "Not Available"),
+            snippet=ref.get("snippet", ""),
+        )
+        for i, ref in enumerate(references, start=1)
+    )
+
+    return f"{output}\n\n-----\nReferences:\n-----\n{formatted_refs}"
+
+
 def main():
     parser = argparse.ArgumentParser(description="Kagi MCP Server")
     parser.add_argument(


### PR DESCRIPTION
Adds a new `kagi_fastgpt` MCP tool that wraps the Kagi FastGPT API
(`POST /api/v0/fastgpt`). FastGPT answers natural-language questions with
a short synthesized response plus numbered web citations, and — unlike
`kagi_search_fetch` — works with any standard Kagi API key without
requiring Search API beta access.

## What's new

- `kagi_fastgpt(query, cache=True)` posts to `/api/v0/fastgpt` and returns
  the answer text followed by a numbered reference list for any cited
  sources. Schema-compatible with the existing FastMCP tool style.
- README: new **Tools** section listing all three tools and calling out
  which require Search API beta access.

## Implementation note

`kagiapi 0.2.1` has a bug in its `KagiClient.fastgpt()` helper: it
serializes the `cache` param as the JSON string `"true"` / `"false"`,
which the FastGPT endpoint rejects with
`{"code": 1, "msg": "Unexpected JSON value for parameter \"cache\""}`.
Sending a real boolean works. This PR bypasses the helper and posts
through the client's authenticated session directly with a real boolean,
so the tool works today against the live API without needing an upstream
`kagiapi` release. Happy to open a separate PR on
[kagisearch/kagiapi](https://github.com/kagisearch/kagiapi) if you'd like.

## Testing

Against a standard key, `kagi_fastgpt(query="What is the capital of Iceland?")`
returns a cited answer; `kagi_fastgpt(query=..., cache=False)` forces a
fresh search. Existing `kagi_summarizer` remains unchanged and verified
working alongside the new tool.