### PR TITLE
docs: Add one-click "Add to Kiro" install badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,27 @@ Now claude code can use the Kagi mcp server. However, claude code comes with its
 }
 ```
 
+### Setup with Kiro
+
+[![Add to Kiro](https://kiro.dev/images/add-to-kiro.svg)](https://kiro.dev/launch/mcp/add?name=kagi&config=%7B%22command%22%3A%22uvx%22%2C%22args%22%3A%5B%22kagimcp%22%5D%2C%22env%22%3A%7B%22KAGI_API_KEY%22%3A%22YOUR_API_KEY_HERE%22%7D%7D)
+
+Or add the following to your Kiro MCP config file (`~/.kiro/settings/mcp.json` for global, or `.kiro/settings/mcp.json` for project-scoped). See the [Kiro MCP documentation](https://kiro.dev/docs/mcp/) for more details.
+
+```json
+{
+  "mcpServers": {
+    "kagi": {
+      "command": "uvx",
+      "args": ["kagimcp"],
+      "env": {
+        "KAGI_API_KEY": "YOUR_API_KEY_HERE",
+        "KAGI_SUMMARIZER_ENGINE": "YOUR_ENGINE_CHOICE_HERE"
+      }
+    }
+  }
+}
+```
+
 ### Pose query that requires use of a tool
 e.g. "Who was time's 2024 person of the year?" for search, or "summarize this video: https://www.youtube.com/watch?v=jNQXAC9IVRw" for summarizer.
 

--- a/README.md
+++ b/README.md
@@ -78,6 +78,10 @@ claude mcp add kagi -e KAGI_API_KEY="YOUR_API_KEY_HERE" -- uvx kagimcp
 npx -y @smithery/cli install kagimcp --client claude
 ```
 
+### Kiro
+
+Add to your Kiro MCP config file (`~/.kiro/settings/mcp.json` for global, or `.kiro/settings/mcp.json` for project-scoped) using the same `mcpServers` JSON as [Claude Desktop](#claude-desktop). See the [Kiro MCP documentation](https://kiro.dev/docs/mcp/) for more details.
+
 ## Usage Examples
 
 - Search: `Who was Time's 2024 person of the year?`


### PR DESCRIPTION
Adds one-click install for [Kiro](https://kiro.dev), an AI-powered IDE.

When clicked, Kiro auto-configures this MCP server — no manual JSON editing needed.

- Added a "Setup with Kiro" section following the same pattern as the existing "Setup with OpenAI" and "Setup with Claude" sections
- Includes one-click badge plus manual JSON config with env vars
- Config file paths included for both global (`~/.kiro/settings/mcp.json`) and project-scoped (`.kiro/settings/mcp.json`)
- Links to [Kiro MCP documentation](https://kiro.dev/docs/mcp/)

Only the README is modified — no other content changed.