### PR TITLE
Documentation for OpenCode config

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,25 @@ npx -y @smithery/cli install kagimcp --client claude
 
 Add to your Kiro MCP config file (`~/.kiro/settings/mcp.json` for global, or `.kiro/settings/mcp.json` for project-scoped) using the same `mcpServers` JSON as [Claude Desktop](#claude-desktop). See the [Kiro MCP documentation](https://kiro.dev/docs/mcp/) for more details.
 
+### OpenCode
+
+Edit the OpenCode configuration file in `~/.config/opencode/opencode.json` and add the following:
+
+```json
+{
+  "mcp": {
+    "kagi": {
+      "type": "local",
+      "command": ["uvx", "kagimcp"],
+      "enabled": true,
+      "environment": {
+        "KAGI_API_KEY": "<YOUR_API_KEY_HERE>"
+      }
+    }
+  }
+}
+```
+
 ## Usage Examples
 
 - Search: `Who was Time's 2024 person of the year?`


### PR DESCRIPTION
Working with OpenCode (Claude code alternative) and thought I'd share my config.  Validated that this works against the prerelease version (main branch/v0 was rejecting my API key).  This config should work when the v1 branch is released and doesn't require the prerelease args to be added.