### PR TITLE
Fastmcp v3 and CORS

### DIFF
--- a/src/kagimcp/server.py
+++ b/src/kagimcp/server.py
@@ -363,19 +363,14 @@ def main():
     args = parser.parse_args()
 
     if args.http:
-        run_kwargs: dict[str, Any] = {
-            "transport": "streamable-http",
-            "host": args.host,
-            "port": args.port,
-            "stateless_http": True,
-        }
+        cors_kwargs: dict[str, Any] = {}
 
         if args.cors_origins:
             from starlette.middleware import Middleware
             from starlette.middleware.cors import CORSMiddleware
 
             origins = [o.strip() for o in args.cors_origins.split(",") if o.strip()]
-            run_kwargs["middleware"] = [
+            cors_kwargs["middleware"] = [
                 Middleware(
                     CORSMiddleware,
                     allow_origins=origins,
@@ -391,7 +386,13 @@ def main():
                 ),
             ]
 
-        mcp.run(**run_kwargs)
+        mcp.run(
+            "streamable-http",
+            host=args.host,
+            port=args.port,
+            stateless_http=True,
+            **cors_kwargs,
+        )
     else:
         mcp.run()  # default stdio mode
 

--- a/src/kagimcp/server.py
+++ b/src/kagimcp/server.py
@@ -353,10 +353,45 @@ def main():
     parser.add_argument(
         "--port", type=int, default=8000, help="Port to listen on (default: 8000)"
     )
+    parser.add_argument(
+        "--cors-origins",
+        type=str,
+        help="Comma-separated list of allowed CORS origins for HTTP mode "
+        "(e.g. 'https://app.example.com,https://localhost:3000'). "
+        "Only applies with --http; omit to disable CORS.",
+    )
     args = parser.parse_args()
 
     if args.http:
-        mcp.run("streamable-http", host=args.host, port=args.port, stateless_http=True)
+        run_kwargs: dict[str, Any] = {
+            "transport": "streamable-http",
+            "host": args.host,
+            "port": args.port,
+            "stateless_http": True,
+        }
+
+        if args.cors_origins:
+            from starlette.middleware import Middleware
+            from starlette.middleware.cors import CORSMiddleware
+
+            origins = [o.strip() for o in args.cors_origins.split(",") if o.strip()]
+            run_kwargs["middleware"] = [
+                Middleware(
+                    CORSMiddleware,
+                    allow_origins=origins,
+                    allow_methods=["GET", "POST", "DELETE", "OPTIONS"],
+                    allow_headers=[
+                        "mcp-protocol-version",
+                        "mcp-session-id",
+                        "Authorization",
+                        "Content-Type",
+                        _TRACE_HEADER,
+                    ],
+                    expose_headers=["mcp-session-id"],
+                ),
+            ]
+
+        mcp.run(**run_kwargs)
     else:
         mcp.run()  # default stdio mode
 


### PR DESCRIPTION
I'm running local llms and exposing them via llama.cpp's built in server. In order to get connections working off of the host machine it needs to support CORS. This PR upgrades from the mcpsdk to FastMCP v3 in order to use the supported middleware features to enable CORS.

Was going to open an issue but this seemed easy enough to just implement. Happy to also break this PR up into an upgrade and a CORS PR. The commits are separated out so it's not hard to break out.

Thanks!